### PR TITLE
Grammar fix

### DIFF
--- a/src/main/resources/assets/teastory/lang/en_US.lang
+++ b/src/main/resources/assets/teastory/lang/en_US.lang
@@ -2,7 +2,7 @@
 itemGroup.tabteastory=Tea，A Story of A Leaf
 
 #Tool tip
-teastory.tooltip.hot_water=§eBe careful to be burned!
+teastory.tooltip.hot_water=§eBe careful or be burned!
 
 #Enchantment
 enchantment.lifeDrain=Life Drain


### PR DESCRIPTION
"Be careful to be burned!" implies you want to be burned, "Be careful or be burned!" warns you to be careful.